### PR TITLE
Build and push docker image with git tag

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,49 @@
+# GitHub Actions 配置说明
+
+## Docker 发布工作流
+
+`docker-publish.yml` 工作流会在你推送以 `v` 开头的 Git tag 时自动触发，构建 Docker 镜像并推送到 DockerHub。
+
+## 配置步骤
+
+### 1. 设置 DockerHub Secrets
+
+在你的 GitHub 仓库中，进入 **Settings** > **Secrets and variables** > **Actions**，添加以下两个 Repository secrets：
+
+- `DOCKERHUB_USERNAME`: 你的 DockerHub 用户名
+- `DOCKERHUB_TOKEN`: 你的 DockerHub Access Token（不是密码）
+
+### 2. 获取 DockerHub Access Token
+
+1. 登录 [DockerHub](https://hub.docker.com/)
+2. 点击右上角头像 > **Account Settings**
+3. 选择 **Security** 选项卡
+4. 点击 **New Access Token**
+5. 输入描述（如：GitHub Actions），选择权限为 **Read, Write, Delete**
+6. 复制生成的 token 并保存到 GitHub Secrets
+
+### 3. 使用方法
+
+创建并推送一个版本 tag：
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+工作流会自动：
+- 构建 Docker 镜像（支持 linux/amd64 和 linux/arm64 架构）
+- 使用 tag 版本号作为镜像标签
+- 推送到 DockerHub
+
+### 4. 镜像命名规则
+
+镜像将使用以下命名格式：
+```
+docker.io/{你的用户名}/qcloud-cos-image-proxy:v1.0.0
+docker.io/{你的用户名}/qcloud-cos-image-proxy:1.0.0
+docker.io/{你的用户名}/qcloud-cos-image-proxy:1.0
+docker.io/{你的用户名}/qcloud-cos-image-proxy:1
+```
+
+其中 `{你的用户名}` 是你的 GitHub 用户名。

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'  # 当推送以 v 开头的 tag 时触发，如 v1.0.0
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: qcloud-cos-image-proxy
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Add a GitHub Actions workflow to automate Docker image building and publishing to DockerHub when a Git tag is pushed.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a9e5e1d-ade5-4004-ae0a-e58430022fc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a9e5e1d-ade5-4004-ae0a-e58430022fc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

